### PR TITLE
Remove for-of loop for es3 compatibility

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -231,7 +231,8 @@ context.subscribe = function(lookup){
     return contextTypes;
   } else {
     var customTypes = {};
-    for (var type of lookup) {
+    for (var i = 0; i < lookup.length; i++) {
+      var type = lookup[i]
       if (contextTypes[type]) {
         customTypes[type] = contextTypes[type];
       } else {


### PR DESCRIPTION
Heya - how about the attached PR?  `for..of` generates code dependent on `Symbol`s.  By replacing it  with an old-school for-loop, there's no need to include babel-polyfill for older browsers.
