### PR TITLE
Fix "Can't find variable: nameOffset"

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -98,6 +98,7 @@ var context = function(Component) {
       var browser;
       var version;
       var verOffset;
+      var nameOffset;
 
       if ((verOffset = UA.indexOf('Opera')) > -1) {
         browser = 'Opera';


### PR DESCRIPTION
Heya - if the browser's useragent isn't recognized, you'd hit a `Can't find variable: nameOffset` error at https://github.com/casesandberg/react-context/blob/master/src/context.js#L132
